### PR TITLE
Capitalize transaction type display

### DIFF
--- a/src/views/categories-list.njk
+++ b/src/views/categories-list.njk
@@ -7,9 +7,9 @@
       <h3 class="card-title">Add Category</h3>
       <form method="POST" action="/categories">
         <label>Name</label>
-        <input name="name" required class="form-control" />
+        <input name="name" required class="form-control" style="border: 1px solid #ced4da;" />
         <label>Type</label>
-        <select name="type" required class="form-select">
+        <select name="type" required class="form-select" style="border: 1px solid #ced4da;">
           <option value="expense">Expense</option>
           <option value="income">Income</option>
         </select>
@@ -21,16 +21,11 @@
   <div class="card">
     <div class="card-body">
       <h3 class="card-title">Existing</h3>
-      <table class="table table-striped">
-        <thead><tr><th>Name</th></tr></thead>
-        <tbody>
-          {% for c in categories %}
-            <tr>
-              <td>{{ c.name }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      <ul class="list-group">
+        {% for c in categories %}
+          <li class="list-group-item">{{ c.name }}</li>
+        {% endfor %}
+      </ul>
     </div>
   </div>
 {% endblock %}

--- a/src/views/dashboard.njk
+++ b/src/views/dashboard.njk
@@ -45,7 +45,7 @@
             {% for t in recent %}
               <tr>
                 <td>{{ t.date }}</td>
-                <td>{{ t.type }}</td>
+                <td>{{ t.type | capitalize }}</td>
                 <td>{{ t.Category.name }}</td>
                 <td>{{ t.amount }}</td>
                 <td>{{ t.description }}</td>

--- a/src/views/transaction-form.njk
+++ b/src/views/transaction-form.njk
@@ -4,26 +4,26 @@
   <h1>{{ title }}</h1>
   <form action="{{ action }}" method="POST">
     <label>Type</label>
-    <select name="type" class="form-select" required>
+    <select name="type" class="form-select" required style="border: 1px solid #ced4da;">
       <option value="expense" {% if transaction.type == 'expense' %}selected{% endif %}>Expense</option>
       <option value="income" {% if transaction.type == 'income' %}selected{% endif %}>Income</option>
     </select>
 
     <label>Amount (€)</label>
-    <input type="number" step="0.01" name="amount" value="{{ transaction.amount or '' }}" class="form-control" required />
+    <input type="number" step="0.01" name="amount" value="{{ transaction.amount or '' }}" class="form-control" required style="border: 1px solid #ced4da;" />
 
     <label>Date</label>
-    <input type="date" name="date" value="{{ transaction.date or '' }}" class="form-control" required />
+    <input type="date" name="date" value="{{ transaction.date or '' }}" class="form-control" required style="border: 1px solid #ced4da;" />
 
     <label>Category</label>
-    <select name="categoryId" class="form-select" required>
+    <select name="categoryId" class="form-select" required style="border: 1px solid #ced4da;">
       {% for c in categories %}
         <option value="{{ c.id }}" {% if transaction.categoryId == c.id %}selected{% endif %}>{{ c.name }}</option>
       {% endfor %}
     </select>
 
     <label>Description</label>
-    <textarea name="description" class="form-control">{{ transaction.description or '' }}</textarea>
+    <textarea name="description" class="form-control" style="border: 1px solid #ced4da;">{{ transaction.description or '' }}</textarea>
 
     <button class="btn btn-primary" type="submit">Save</button>
   </form>

--- a/src/views/transactions-list.njk
+++ b/src/views/transactions-list.njk
@@ -5,13 +5,13 @@
 
   <form method="GET" style="margin-bottom:1rem;">
     <label>Type</label>
-    <select name="type" class="form-select">
+    <select name="type" class="form-select" style="border: 1px solid #ced4da;">
       <option value="">All</option>
       <option value="income" {% if filters.type == 'income' %}selected{% endif %}>Income</option>
       <option value="expense" {% if filters.type == 'expense' %}selected{% endif %}>Expense</option>
     </select>
     <label>Category</label>
-    <select name="category" class="form-select">
+    <select name="category" class="form-select" style="border: 1px solid #ced4da;">
       <option value="">All</option>
       {% for c in categories %}
         <option value="{{ c.id }}" {% if filters.category == c.id %}selected{% endif %}>{{ c.name }}</option>
@@ -30,7 +30,7 @@
       {% for t in transactions %}
         <tr>
           <td>{{ t.date }}</td>
-          <td>{{ t.type }}</td>
+          <td>{{ t.type | capitalize }}</td>
           <td>{{ t.Category.name }}</td>
           <td>{{ t.amount }}</td>
           <td>{{ t.description }}</td>


### PR DESCRIPTION
## Summary
- Capitalize transaction types in dashboard and transaction list views for clearer display
- Add light borders to transaction filters, transaction form fields, and category fields with bordered list of existing categories

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689baa74f5c88321a17a7bbfd40c7ecc